### PR TITLE
general bug fixes to utils/cli.py

### DIFF
--- a/netgrasp/netgrasp.py
+++ b/netgrasp/netgrasp.py
@@ -245,7 +245,7 @@ def main(*pcap):
 
     try:
         ng.db = database.Database()
-    except Exception as e:
+    except Exception:
         ng.debugger.dump_exception("main() caught exception creating database")
         ng.debugger.critical("failed to open or create %s (as user %s), exiting", (ng.database["filename"], ng.debugger.whoami()))
     ng.debugger.info("opened %s as user %s", (ng.database["filename"], ng.debugger.whoami()))
@@ -372,7 +372,7 @@ def wiretap(pc, child_conn):
         ng.db = database.Database()
     except Exception as e:
         ng.debugger.error("%s", (e,))
-        ng.debugger.critical("failed to open or create %s (as user %s), exiting", (database["filename"], ng.debugger.whoami()))
+        ng.debugger.critical("failed to open or create %s (as user %s), exiting", (ng.database["filename"], ng.debugger.whoami()))
 
     ng.debugger.info("opened %s as user %s", (ng.database["filename"], ng.debugger.whoami()))
     ng.db.cursor = ng.db.connection.cursor()
@@ -509,7 +509,6 @@ def ip_has_changed(did):
 
 # Database definitions.
 def create_database():
-    from utils import exclusive_lock
     ng = netgrasp_instance
 
     try:
@@ -904,7 +903,6 @@ def device_request(ip, mac):
         # Log request.
         ng.db.cursor.execute("SELECT request.rid, request.active FROM request WHERE request.ip = ? ORDER BY updated DESC LIMIT 1", (ip,))
         seen = ng.db.cursor.fetchone()
-        rid, active = (False, False)
         if seen:
             rid, active = seen
             if active:
@@ -1273,8 +1271,6 @@ def detect_stale_ips():
     ng = netgrasp_instance
 
     try:
-        from utils import exclusive_lock
-
         ng.debugger.debug("entering detect_stale_ips()")
         stale = datetime.datetime.now() - datetime.timedelta(seconds=ng.listen["active_timeout"])
 
@@ -1317,8 +1313,6 @@ def detect_netscans():
     ng = netgrasp_instance
 
     try:
-        from utils import exclusive_lock
-
         ng.debugger.debug("entering detect_netscans()")
         now = datetime.datetime.now()
         stale = datetime.datetime.now() - datetime.timedelta(seconds=ng.listen["active_timeout"]) - datetime.timedelta(minutes=10)
@@ -1345,8 +1339,6 @@ def detect_anomalies():
     ng = netgrasp_instance
 
     try:
-        from utils import exclusive_lock
-
         ng.debugger.debug("entering detect_anomalies()")
         stale = datetime.datetime.now() - datetime.timedelta(seconds=ng.listen["active_timeout"])
 
@@ -1397,8 +1389,6 @@ def send_notifications():
     ng = netgrasp_instance
 
     try:
-        from utils import exclusive_lock
-
         ng.debugger.debug("entering send_notifications()")
 
         if not ng.notification["enabled"]:
@@ -1480,9 +1470,6 @@ def send_email_alerts():
     ng = netgrasp_instance
 
     try:
-        from utils import exclusive_lock
-        from utils import email
-
         ng.debugger.debug("entering send_email_alerts()")
 
         if not ng.email["enabled"]:
@@ -1629,8 +1616,6 @@ def mac_lookup(mac):
     ng = netgrasp_instance
 
     try:
-        from utils import exclusive_lock
-
         ng.debugger.debug("entering mac_lookup(%s)", (mac,))
 
         import re
@@ -1715,9 +1700,6 @@ def send_email_digests():
     ng = netgrasp_instance
 
     try:
-        from utils import exclusive_lock
-        from utils import email
-
         ng.debugger.debug("entering send_email_digests()")
 
         if not ng.email["enabled"]:
@@ -1881,8 +1863,6 @@ def garbage_collection():
     ng = netgrasp_instance
 
     try:
-        from utils import exclusive_lock
-
         ng.debugger.debug("entering garbage_collection()")
 
         if not ng.database["gcenabled"]:

--- a/netgrasp/utils/pretty.py
+++ b/netgrasp/utils/pretty.py
@@ -1,10 +1,12 @@
+import datetime
+
+
 def time_ago(elapsed):
     from netgrasp import netgrasp
+
     ng = netgrasp.netgrasp_instance
 
     try:
-        import datetime
-
         ng.debugger.debug("time_ago(%s)", (elapsed,))
 
         if not elapsed:
@@ -40,16 +42,16 @@ def time_ago(elapsed):
             return str(day_diff / 30) + " months ago"
         return str(day_diff / 365) + " years ago"
 
-    except exception as e:
+    except Exception:
         ng.debugger.dump_exception("time_ago() fixme")
+
 
 def time_elapsed(elapsed):
     from netgrasp import netgrasp
+
     ng = netgrasp.netgrasp_instance
 
     try:
-        import datetime
-
         ng.debugger.debug("time_elapsed(%s)", (elapsed,))
 
         if not elapsed:
@@ -83,17 +85,17 @@ def time_elapsed(elapsed):
             return str(day_diff / 30) + " months"
         return str(day_diff / 365) + " years"
 
-    except Exception as e:
+    except Exception:
         ng.debugger.dump_exception("time_elapsed() caught exception")
 
+
 # Provides a human-friendly name for a mac-ip pair.
-def name_did(did, ip = None):
+def name_did(did, ip=None):
     from netgrasp import netgrasp
+
     ng = netgrasp.netgrasp_instance
 
     try:
-        import datetime
-
         ng.debugger.debug("entering name_did(%s, %s)", (did, ip))
 
         if did:
@@ -105,7 +107,7 @@ def name_did(did, ip = None):
                 elif hostname and (hostname != "unknown"):
                     return hostname
                 elif vendor:
-                    return """%s device""" % (vendor)
+                    return """%s device""" % vendor
                 else:
                     return """%s [%s]""" % (ip, mac)
 
@@ -117,11 +119,12 @@ def name_did(did, ip = None):
 
         return "Unrecognized device"
 
-    except Exception as e:
+    except Exception:
         ng.debugger.dump_exception("name_did() caught exception")
 
+
 # Truncate strings when they're too long.
-def truncate_string(string, maxlength, suffix = "..."):
+def truncate_string(string, maxlength, suffix="..."):
     if not string or len(string) <= maxlength:
         return string
     return """%s%s""" % (string[:(maxlength - len(suffix))], suffix)


### PR DESCRIPTION
So this started out as an attempt to be able to run ng in
the foreground and still send "signals"/commands to it (pidfile).
It ended up not being worth it with subprocesses, pipes, etc.
I.e. just start it, let it daemonize/fork and tail -f.
That's why there's the pep8 "collateral damage" in pretty and
netgrasp.

- Fix invalid var references.
- Refactor module usage/redundant imports.
- Minor formatting.